### PR TITLE
IDEX-3409: Reconfigure ports for JMX/RMI server

### DIFF
--- a/onpremises-ide-packaging-tomcat-ext-server/src/assembly/server.xml
+++ b/onpremises-ide-packaging-tomcat-ext-server/src/assembly/server.xml
@@ -31,8 +31,8 @@
     <Listener className="org.apache.catalina.core.JreMemoryLeakPreventionListener" />
     <Listener className="org.apache.catalina.mbeans.GlobalResourcesLifecycleListener" />
     <Listener className="org.apache.catalina.core.ThreadLocalLeakPreventionListener" />
-    <Listener className="org.apache.catalina.mbeans.JmxRemoteLifecycleListener" rmiRegistryPortPlatform="32001"
-              rmiServerPortPlatform="32101"/>
+    <Listener className="org.apache.catalina.mbeans.JmxRemoteLifecycleListener" rmiRegistryPortPlatform="32002"
+              rmiServerPortPlatform="32102"/>
 
     <!-- Global JNDI resources
          Documentation at /docs/jndi-resources-howto.html


### PR DESCRIPTION
It's a common configuration in server.xml that needed for specific use cases
e.g. start Che on ws-agent and in this case you should have ws-agent with different JMX/RMI ports configuration.

@skabashnyuk 