### PR TITLE
CHE-314. Exclude che-core-api-analytics from packaging into onpremises-ide-packaging-war-ext-server

### DIFF
--- a/onpremises-ide-packaging-war-ext-server/pom.xml
+++ b/onpremises-ide-packaging-war-ext-server/pom.xml
@@ -105,11 +105,6 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.plugin</groupId>
-            <artifactId>che-plugin-git-ext-git</artifactId>
-            <type>jar</type>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.che.plugin</groupId>
             <artifactId>che-plugin-git-provider-che</artifactId>
         </dependency>
         <dependency>
@@ -183,7 +178,10 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
                 <configuration>
-                    <packagingExcludes>WEB-INF/lib/*gwt*.jar,WEB-INF/lib/gin-*.jar</packagingExcludes>
+                    <packagingExcludes>WEB-INF/lib/*gwt*.jar,
+                        WEB-INF/lib/gin-*.jar,
+                        WEB-INF/lib/che-core-api-analytics-*.jar
+                    </packagingExcludes>
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
Signed-off-by: Roman Nikitenko <rnikitenko@codenvy.com>